### PR TITLE
fix: reposition previous button in family information form

### DIFF
--- a/InnolabAMS/resources/views/family_information/create.blade.php
+++ b/InnolabAMS/resources/views/family_information/create.blade.php
@@ -2,11 +2,7 @@
 @extends('portal')
 
 @section('content')
-<div class="flex justify-between items-center mb-4">
-    <h1 class="text-2xl font-semibold mx-4 my-4">Family Information</h1>
-</div>
-
-<!-- Previous button outside the form -->
+<!-- Previous button -->
 <div class="mb-4">
     <a href="{{ route('form.personal_info') }}" 
        class="bg-gray-500 text-white px-6 py-2 rounded hover:bg-gray-600">
@@ -14,8 +10,10 @@
     </a>
 </div>
 
-<div class="bg-white rounded-lg shadow-lg p-6">
+
     <!-- Parent Information Form -->
+     <div class="bg-white rounded-lg shadow-lg p-6">
+     <h2 class="text-xl font-semibold mb-4">Family Information</h2>
     <form id="parentForm" class="mb-8">
         <!-- Father's Section -->
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">


### PR DESCRIPTION
## 🎯 Implementation Notes
- ✨ Repositioned Previous button to match wireframe layout
- 🎨 Maintained consistent button styling
- 📱 Ensured proper spacing and alignment

## 🧪 Testing Checklist
- [x] Previous button appears in correct position
- [x] Previous button retains original functionality
- [x] Button styling matches design system
- [x] Proper spacing between button and form content
- [x] Navigation to previous page works correctly

## 📸 Screenshots
Before:
![image](https://github.com/user-attachments/assets/880a6963-1603-4882-b7ee-453adadf1d89)

After:
![image](https://github.com/user-attachments/assets/a241306e-a65f-453b-953d-c1ff2c5c076f)

## 👥 Reviewers
- 👨‍💻 @JamesAlbertDavid 
- 👨‍💻 @rvcarcueva2 