### PR TITLE
fix: correct menu highlighting in portal sidebar

### DIFF
--- a/InnolabAMS/resources/views/portal.blade.php
+++ b/InnolabAMS/resources/views/portal.blade.php
@@ -36,7 +36,7 @@
                 <li>
                     <a href="{{ route('additional_info.create') }}" 
                     class="flex items-center py-2 px-6 hover:bg-gray-300 rounded transition duration-200 ease-in-out
-                            {{ request()->routeIs('educational-background.*') ? 'bg-gray-200' : '' }}">
+                            {{ request()->routeIs('additional_info.*') ? 'bg-gray-200' : '' }}">
                         <i class="fa-solid fa-graduation-cap w-6 text-center"></i>
                         <span class="font-semibold ml-6">{{ __('Additional Information') }}</span>
                     </a>


### PR DESCRIPTION
## 🎯 Implementation Notes
- ✨ Fixed route check for Additional Information menu item
- 🐛 Corrected incorrect highlighting when Educational Background is active
- 🎨 Maintained consistent active state behavior across menu items

## 🧪 Testing Checklist
- [x] Only Educational Background highlights when selected
- [x] Only Additional Information highlights when selected  
- [x] Other menu items highlight correctly
- [x] Active state styling remains consistent

## 📷 Screenshots
before: 
![image](https://github.com/user-attachments/assets/dc60b975-3483-4934-aea8-aadd45ee0ba1)

after: 
![image](https://github.com/user-attachments/assets/c095f152-c6e9-48de-9937-62aa930e0e5c)

## 👥 Reviewers
- 👨‍💻 @JamesAlbertDavid 
- 👨‍💻 @rvcarcueva2