### PR TITLE
feat: Add file upload validation and improve Form 137 input styling

### DIFF
--- a/InnolabAMS/app/Http/Requests/StoreApplicationRequest.php
+++ b/InnolabAMS/app/Http/Requests/StoreApplicationRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreApplicationRequest extends FormRequest
+{
+    public function rules()
+    {
+        return [
+            'form_137' => [
+                'nullable',
+                'file',
+                'mimes:pdf,jpg,jpeg,png',
+                'max:10240', 
+            ],
+        ];
+    }
+}

--- a/InnolabAMS/resources/views/admission/create.blade.php
+++ b/InnolabAMS/resources/views/admission/create.blade.php
@@ -436,11 +436,18 @@
                                 class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50"></textarea>
                         </div>
                         <div class="mb-6">
-                            <label class="block text-sm font-medium text-gray-700">Form 137</label>
+                            <label class="block text-sm font-medium text-gray-700 mb-1">Form 137</label>
                             <input type="file"
                                 name="form_137"
-                                accept=".pdf,.doc,.docx"
-                                class="mt-1 block w-full">
+                                accept=".pdf,.jpg,.jpeg,.png"
+                                x-on:change="
+                                    if ($event.target.files[0]?.size > 10 * 1024 * 1024) {
+                                        $event.target.value = '';
+                                        alert('File size must not exceed 10MB');
+                                    }
+                                "
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
+                            <p class="mt-1 text-sm text-gray-500">Upload PDF/JPG/PNG files only (max: 10MB)</p>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Changes Made
- Added file size validation (10MB limit) for Form 137 uploads
- Added frontend validation using Alpine.js to check file size before upload
- Added backend validation in StoreApplicationRequest
- Improved Form 137 input field styling and helper text
- Added supported file type indicators (PDF/JPG/PNG)

## Technical Details
- Frontend validation prevents uploads over 10MB with user feedback
- Backend validation enforces:
  - File size limit: 10MB (10240 KB)
  - Allowed file types: PDF, JPG, JPEG, PNG
  - Optional upload (nullable)
- Improved UI with clear helper text and consistent form styling
